### PR TITLE
Feature/issue256

### DIFF
--- a/grails-app/assets/javascripts/forms-knockout-bindings.js
+++ b/grails-app/assets/javascripts/forms-knockout-bindings.js
@@ -1147,6 +1147,21 @@
     };
 
     /**
+     * The role of this extender is to provide a function the view model can use to render a list of
+     * values selected using a multi select component (select2Many / selectMany) that have also used a
+     * label/value configuration for the options.
+     * @param target the observable.
+     * @param options unused
+     */
+    ko.extenders.toReadOnlyString = function(target, options) {
+        target.toReadOnlyString = function() {
+            var values = ko.utils.unwrapObservable(target);
+            var labels = target.constraints && _.isFunction(target.constraints.label) ? _.map(values, target.constraints.label) : values;
+            return labels.join(', ');
+        }
+    }
+
+    /**
      * This is kind of a hack to make the closure config object available to the any components that use the model.
      */
     ko.extenders.configurationContainer = function(target, config) {

--- a/grails-app/assets/javascripts/forms.js
+++ b/grails-app/assets/javascripts/forms.js
@@ -1050,7 +1050,7 @@ function orEmptyArray(v) {
                 if (match) {
                     return self.constraints.text(match);
                 }
-                return '';
+                return value || '';
             }
         }
 

--- a/grails-app/taglib/au/org/ala/ecodata/forms/ModelJSTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/ecodata/forms/ModelJSTagLib.groovy
@@ -732,7 +732,8 @@ class ModelJSTagLib {
     }
 
     def stringListViewModel(JSModelRenderContext ctx) {
-        observableArray(ctx)
+        String extender = '{toReadOnlyString:true}'
+        observableArray(ctx, [extender])
     }
 
     def setViewModel(JSModelRenderContext ctx) {

--- a/src/main/groovy/au/org/ala/ecodata/forms/ViewModelWidgetRenderer.groovy
+++ b/src/main/groovy/au/org/ala/ecodata/forms/ViewModelWidgetRenderer.groovy
@@ -72,9 +72,23 @@ class ViewModelWidgetRenderer implements ModelWidgetRenderer {
         context.writer << "<span ${context.attributes.toString()} data-bind='${context.databindAttrs.toString()}'></span>"
     }
 
+    /**
+     * The binding looks for the toReadOnlyString function because there exist some misconfigurations that
+     * use a "text" data model item with a selectMany/select2Many view.  This is a workaround to prevent exceptions.
+     */
+    private static String selectManyBindingString(WidgetRenderContext context) {
+        '_.isFunction(('+context.source+' || []).toReadOnlyString) ? '+ context.source+'.toReadOnlyString() : ('+context.source+'() || []).join(", ")'
+    }
+
     @Override
     void renderSelectMany(WidgetRenderContext context) {
-        context.databindAttrs.add 'text', '('+context.source+'() || []).join(", ")'
+        context.databindAttrs.add 'text',selectManyBindingString(context)
+        context.writer << "<span ${context.attributes.toString()} data-bind='${context.databindAttrs.toString()}'></span>"
+    }
+
+    @Override
+    void renderSelect2Many(WidgetRenderContext context) {
+        context.databindAttrs.add 'text', selectManyBindingString(context)
         context.writer << "<span ${context.attributes.toString()} data-bind='${context.databindAttrs.toString()}'></span>"
     }
 
@@ -193,12 +207,6 @@ class ViewModelWidgetRenderer implements ModelWidgetRenderer {
     void renderCurrency(WidgetRenderContext context) {
         context.databindAttrs.add 'text', context.source
         context.writer << """\$<span data-bind='${context.databindAttrs.toString()}'></span>.00"""
-    }
-
-    @Override
-    void renderSelect2Many(WidgetRenderContext context) {
-        context.databindAttrs.add 'text', '('+context.source+'() || []).join(", ")'
-        context.writer << "<span ${context.attributes.toString()} data-bind='${context.databindAttrs.toString()}'></span>"
     }
 
     @Override

--- a/src/test/js/spec/DataModelItemSpec.js
+++ b/src/test/js/spec/DataModelItemSpec.js
@@ -90,7 +90,7 @@ describe("DataModelItem Spec", function () {
         dataItem('2');
         expect(dataItem.constraints.label()).toEqual('2')
         expect(dataItem.constraints.label('3')).toEqual('3')
-        expect(dataItem.constraints.label("does not exist")).toEqual('');
+        expect(dataItem.constraints.label("does not exist")).toEqual('does not exist'); // Support for tags and historical constraints that have been removed.
 
         var objectConstraints = [{text:'label 1', value:'1'}, {text:'label 2', value:'2'}, {text:'label 3', value:'3'}];
         metadata.constraints = {
@@ -104,7 +104,7 @@ describe("DataModelItem Spec", function () {
         dataItem('2');
         expect(dataItem.constraints.label()).toEqual('label 2')
         expect(dataItem.constraints.label('3')).toEqual('label 3')
-        expect(dataItem.constraints.label("does not exist")).toEqual('');
+        expect(dataItem.constraints.label("does not exist")).toEqual('does not exist'); // Support for tags and historical constraints that have been removed.
 
         metadata.constraints = {
             type:"pre-populated",

--- a/src/test/js/spec/DataModelItemSpec.js
+++ b/src/test/js/spec/DataModelItemSpec.js
@@ -128,7 +128,6 @@ describe("DataModelItem Spec", function () {
         deferred.resolve(objectConstraints).then(function() {
             expect(dataItem.constraints.label()).toEqual('label 2')
             expect(dataItem.constraints.label('3')).toEqual('label 3')
-            expect(dataItem.constraints.label("does not exist")).toEqual('');
 
             done();
         });


### PR DESCRIPTION
The issue driving this fix is to display the selected data set names in the view mode of the "Synthesising and finalising baseline data" service which is currently displaying the data set id in view mode.

Note it needs a form update as the dataType of the "datasetSupports" attribute was incorrectly set to "text" - see [21655531bfd17fde022c8fb1a518e3414f5c07dd](https://github.com/AtlasOfLivingAustralia/fieldcapture/commit/21655531bfd17fde022c8fb1a518e3414f5c07dd)