### PR TITLE
Reused existing check for default column labels in tables but include override #315

### DIFF
--- a/grails-app/taglib/au/org/ala/ecodata/forms/ModelTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/ecodata/forms/ModelTagLib.groovy
@@ -579,18 +579,18 @@ class ModelTagLib {
         // These two items must add up to 12, and determine the space allocated to the label and input field
         // respectively in the row.
         // For tables with controls without labels (which is most of time), use col-12
-        int labelColWidth = 4
-        int inputFieldColWidth = layoutContext.hasTableAncestor ? 12 : 8
+        Boolean labelAboveField = model.labelAboveField
+        if (labelAboveField == null) {
+            labelAboveField = layoutContext.hasTableAncestor
+        }
+
+        int labelColWidth = labelAboveField ? 12 : (model.labelColWidth ?: 4)
+        int inputFieldColWidth = labelAboveField ? 12 : (LAYOUT_COLUMNS - labelColWidth)
         switch (layoutContext.parentView) {
             case 'col':
                 out << "<div class=\"row form-group\">"
-                if (model.fullWidthLabelAbove) {
-                    labelAttributes.addSpan 'col-sm-12'
-                    dataTag = "<div class=\"col-sm-12\">"+dataTag+"</div>"
-                } else {
-                    labelAttributes.addSpan 'col-sm-'+labelColWidth
-                    dataTag = "<div class=\"col-sm-${inputFieldColWidth}\">"+dataTag+"</div>"
-                }
+                labelAttributes.addSpan 'col-sm-'+labelColWidth
+                dataTag = "<div class=\"col-sm-${inputFieldColWidth}\">"+dataTag+"</div>"
                 break
             case 'table':
                 if (model.type == 'boolean') {


### PR DESCRIPTION
I realised when making the updates for Todd that we already had a flag we were using to control the field width in table columns so I reused that as a default for the label as well.  Added an override that can be used inside and outside of tables to get the label above field or label next to field behaviour.