### PR TITLE
Remove `input-group-prepend` and `input-group-append` from the speciesTemplate

### DIFF
--- a/grails-app/views/output/_speciesTemplate.gsp
+++ b/grails-app/views/output/_speciesTemplate.gsp
@@ -1,18 +1,10 @@
 <div class="${css} autocompleteSpecies input-group" data-bind="with:${source}">
-    <div class="input-group-prepend">
-        <span class="input-group-text" data-bind="visible:!transients.editing(), css:{'btn-success':name()}"><i class="fa fa-check"
-                                                                                                      data-bind="css:{'fa-check':listId()!='unmatched' && name(), 'fa-question-o':listId()=='unmatched' || listId() == 'error-unmatched'}"></i>
-        </span>
-    </div>
-    <div class="input-group-prepend">
-        <span class="input-group-text" data-bind="visible:transients.editing()"><asset:image src="ajax-saver.gif"
-                                                                                   alt="saving icon"/></span>
-    </div>
+    <span class="input-group-text" data-bind="visible:!transients.editing(), css:{'btn-success':name()}"><i class="fa fa-check"
+                                                                                                  data-bind="css:{'fa-check':listId()!='unmatched' && name(), 'fa-question-o':listId()=='unmatched' || listId() == 'error-unmatched'}"></i>
+    </span>
+    <span class="input-group-text" data-bind="visible:transients.editing()"><asset:image src="ajax-saver.gif" alt="saving icon"/></span>
     <input type="text" class="form-control form-control-sm speciesInputTemplates" data-bind="${databindAttrs}" ${validationAttrs}/>
-    <div class="input-group-append">
-        <span class="input-group-text" data-bind="visible: !transients.editing() && name()">
-            <a data-bind="popover: {title: name, content: transients.speciesInformation}, event: { 'shown.bs.popover': fetchSpeciesImage}"><i class="fa fa-info-circle"></i></a>
-        </span>
-    </div>
-
+    <span class="input-group-text" data-bind="visible: !transients.editing() && name()">
+        <a data-bind="popover: {title: name, content: transients.speciesInformation}, event: { 'shown.bs.popover': fetchSpeciesImage}"><i class="fa fa-info-circle"></i></a>
+    </span>
 </div>


### PR DESCRIPTION
This PR removes the old `input-group-prepend` and `input-group-append` wrappers for the speciesTemplate component, allowing it to be rendered correctly in BS5