### PR TITLE
Made image attribution & notes visibility configurable, and CC-BY 4.0 the default license option

### DIFF
--- a/grails-app/conf/example_models/images.json
+++ b/grails-app/conf/example_models/images.json
@@ -36,10 +36,12 @@
               "type": "image"
             },
             {
-              "preLabel": "Hide metadata and show remove button with image behaviour:",
+              "preLabel": "Hide metadata, attribution, notes and show remove button with image behaviour:",
               "source": "images3",
               "type": "image",
               "showMetadata": false,
+              "showAttribution": false,
+              "showNotes": false,
               "displayOptions": {
                 "showRemoveButtonWithImage": true
               }

--- a/grails-app/views/output/_imageDataTypeEditModelTemplate.gsp
+++ b/grails-app/views/output/_imageDataTypeEditModelTemplate.gsp
@@ -56,15 +56,15 @@
                     </div>
                     <div class="col-sm-8">
                         <select id="licence" data-bind="value:licence" class="form-select form-select-sm col-sm-12">
+                            <option value="CC BY 4.0">Creative Commons Attribution 4.0</option>
                             <option value="CC BY 3.0">Creative Commons Attribution 3.0</option>
                             <option value="CC BY 0">Creative Commons Attribution 0</option>
-                            <option value="CC BY 4.0">Creative Commons Attribution 4.0</option>
                             <option value="CC BY-NC">Creative Commons Attribution-Noncommercial</option>
                         </select>
                     </div>
                 </div>
 
-                <div class="row">
+                <div class="row" style="display:${showImgAttribution};">
                     <div class="col-sm-4 text-start">
                         <label class="control-label" for="attribution">
                             Attribution: <i class="fa fa-question-circle" data-bind="popover:{content:'The name of the photographer', placement:'top'}">&nbsp;</i>
@@ -76,7 +76,7 @@
                 </div>
 
 
-                <div class="row">
+                <div class="row" style="display:${showImgNotes};">
                     <div class="col-sm-4 text-start">
                         <label class="control-label" for="notes">Notes: <i class="fa fa-question-circle" data-bind="popover:{content:'Additional notes you would like to supply regarding the photo point or photograph.', placement:'top'}">&nbsp;</i></label>
                     </div>

--- a/grails-app/views/output/_imageDataTypeEditModelTemplate.gsp
+++ b/grails-app/views/output/_imageDataTypeEditModelTemplate.gsp
@@ -51,15 +51,15 @@
                 <div class="row">
                     <div class="col-sm-4 text-start">
                         <label class="control-label">Licence: <i class="fa fa-question-circle"
-                                                                data-bind="popover:{content:'Creative Commons Attribution (CC BY), Creative Commons-Noncommercial (CC BY-NC), Creative Commons Attribution-Share Alike (CC BY-SA), Creative Commons Attribution-Noncommercial-Share Alike (CC BY-NC-SA)', placement:'top'}">&nbsp;</i>
+                                                                data-bind="popover:{content:'Creative Commons Attribution (CC BY), Creative Commons-Noncommercial (CC BY-NC), Creative Commons Zero (CC0)', placement:'top'}">&nbsp;</i>
                         </label>
                     </div>
                     <div class="col-sm-8">
                         <select id="licence" data-bind="value:licence" class="form-select form-select-sm col-sm-12">
                             <option value="CC BY 4.0">Creative Commons Attribution 4.0</option>
                             <option value="CC BY 3.0">Creative Commons Attribution 3.0</option>
-                            <option value="CC BY 0">Creative Commons Attribution 0</option>
                             <option value="CC BY-NC">Creative Commons Attribution-Noncommercial</option>
+                            <option value="CC BY 0">Creative Commons Zero</option>
                         </select>
                     </div>
                 </div>

--- a/grails-app/views/output/_imageDataTypeEditModelTemplate.gsp
+++ b/grails-app/views/output/_imageDataTypeEditModelTemplate.gsp
@@ -64,26 +64,30 @@
                     </div>
                 </div>
 
-                <div class="row" style="display:${showImgAttribution};">
-                    <div class="col-sm-4 text-start">
-                        <label class="control-label" for="attribution">
-                            Attribution: <i class="fa fa-question-circle" data-bind="popover:{content:'The name of the photographer', placement:'top'}">&nbsp;</i>
-                        </label>
+                <g:if test="${showImgAttribution}">
+                    <div class="row">
+                        <div class="col-sm-4 text-start">
+                            <label class="control-label" for="attribution">
+                                Attribution: <i class="fa fa-question-circle" data-bind="popover:{content:'The name of the photographer', placement:'top'}">&nbsp;</i>
+                            </label>
+                        </div>
+                        <div class="col-sm-8">
+                            <input id="attribution" class="form-control form-control-sm full-width-input" type="text" data-bind="value:attribution">
+                        </div>
                     </div>
-                    <div class="col-sm-8">
-                        <input id="attribution" class="form-control form-control-sm full-width-input" type="text" data-bind="value:attribution">
-                    </div>
-                </div>
+                </g:if>
 
 
-                <div class="row" style="display:${showImgNotes};">
-                    <div class="col-sm-4 text-start">
-                        <label class="control-label" for="notes">Notes: <i class="fa fa-question-circle" data-bind="popover:{content:'Additional notes you would like to supply regarding the photo point or photograph.', placement:'top'}">&nbsp;</i></label>
+                <g:if test="${showImgNotes}">
+                    <div class="row">
+                        <div class="col-sm-4 text-start">
+                            <label class="control-label" for="notes">Notes: <i class="fa fa-question-circle" data-bind="popover:{content:'Additional notes you would like to supply regarding the photo point or photograph.', placement:'top'}">&nbsp;</i></label>
+                        </div>
+                        <div class="col-sm-8">
+                            <input id="notes" class="form-control form-control-sm full-width-input" type="text" data-bind="value:notes">
+                        </div>
                     </div>
-                    <div class="col-sm-8">
-                        <input id="notes" class="form-control form-control-sm full-width-input" type="text" data-bind="value:notes">
-                    </div>
-                </div>
+                </g:if>
 
                 <div class="row readonly ">
                     <div class="col-sm-4 text-start">

--- a/src/integration-test/groovy/au/org/ala/ecodata/forms/ImageTypeSpec.groovy
+++ b/src/integration-test/groovy/au/org/ala/ecodata/forms/ImageTypeSpec.groovy
@@ -57,7 +57,7 @@ class ImageTypeSpec extends GebReportingSpec {
 
         and: "The metadata, attribution and notes fields configured as hidden are not displayed"
         $(".fileupload-buttonbar:nth-child(3) .image-title-input").displayed == false
-        $(".fileupload-buttonbar:nth-child(3) input[data-bind='value:attribution']").displayed == false
-        $(".fileupload-buttonbar:nth-child(3) input[data-bind='value:notes']").displayed == false
+        $(".fileupload-buttonbar:nth-child(3) input[data-bind='value:attribution']").size() == 0
+        $(".fileupload-buttonbar:nth-child(3) input[data-bind='value:notes']").size() == 0
     }
 }

--- a/src/integration-test/groovy/au/org/ala/ecodata/forms/ImageTypeSpec.groovy
+++ b/src/integration-test/groovy/au/org/ala/ecodata/forms/ImageTypeSpec.groovy
@@ -54,6 +54,10 @@ class ImageTypeSpec extends GebReportingSpec {
 
         and: "The remove button is displayed below image"
         $("a.remove-btn-with-image").size() == 1
+
+        and: "The metadata, attribution and notes fields configured as hidden are not displayed"
         $(".fileupload-buttonbar:nth-child(3) .image-title-input").displayed == false
+        $(".fileupload-buttonbar:nth-child(3) input[data-bind='value:attribution']").displayed == false
+        $(".fileupload-buttonbar:nth-child(3) input[data-bind='value:notes']").displayed == false
     }
 }

--- a/src/main/groovy/au/org/ala/ecodata/forms/EditModelWidgetRenderer.groovy
+++ b/src/main/groovy/au/org/ala/ecodata/forms/EditModelWidgetRenderer.groovy
@@ -276,8 +276,8 @@ public class EditModelWidgetRenderer implements ModelWidgetRenderer {
     void renderImage(WidgetRenderContext context) {
         context.databindAttrs.add 'imageUpload', "{target:${context.source}, context:\$context, config:{}}"
         def showImgMetadata = (context.model.showMetadata == null ||  context.model.showMetadata == true) ? "block" :"none"
-        def showImgAttribution = (context.model.showAttribution == null ||  context.model.showAttribution == true) ? "block" :"none"
-        def showImgNotes = (context.model.showNotes == null ||  context.model.showNotes == true) ? "block" :"none"
+        def showImgAttribution = context.model.showAttribution == null ||  context.model.showAttribution == true
+        def showImgNotes = context.model.showNotes == null ||  context.model.showNotes == true
         def allowImageAdd = (context.model.allowImageAdd == null ||  context.model.allowImageAdd == true) ? "block" :"none"
         context.writer << context.g.render(template: '/output/imageDataTypeEditModelTemplate', plugin:'ecodata-client-plugin', model: [databindAttrs:context.databindAttrs.toString(), showImgMetadata: showImgMetadata, showImgAttribution: showImgAttribution, showImgNotes: showImgNotes, allowImageAdd: allowImageAdd, name: context.source, validationAttrs:context.validationAttr, options: context.model.displayOptions])
     }

--- a/src/main/groovy/au/org/ala/ecodata/forms/EditModelWidgetRenderer.groovy
+++ b/src/main/groovy/au/org/ala/ecodata/forms/EditModelWidgetRenderer.groovy
@@ -276,8 +276,10 @@ public class EditModelWidgetRenderer implements ModelWidgetRenderer {
     void renderImage(WidgetRenderContext context) {
         context.databindAttrs.add 'imageUpload', "{target:${context.source}, context:\$context, config:{}}"
         def showImgMetadata = (context.model.showMetadata == null ||  context.model.showMetadata == true) ? "block" :"none"
+        def showImgAttribution = (context.model.showAttribution == null ||  context.model.showAttribution == true) ? "block" :"none"
+        def showImgNotes = (context.model.showNotes == null ||  context.model.showNotes == true) ? "block" :"none"
         def allowImageAdd = (context.model.allowImageAdd == null ||  context.model.allowImageAdd == true) ? "block" :"none"
-        context.writer << context.g.render(template: '/output/imageDataTypeEditModelTemplate', plugin:'ecodata-client-plugin', model: [databindAttrs:context.databindAttrs.toString(), showImgMetadata: showImgMetadata, allowImageAdd: allowImageAdd, name: context.source, validationAttrs:context.validationAttr, options: context.model.displayOptions])
+        context.writer << context.g.render(template: '/output/imageDataTypeEditModelTemplate', plugin:'ecodata-client-plugin', model: [databindAttrs:context.databindAttrs.toString(), showImgMetadata: showImgMetadata, showImgAttribution: showImgAttribution, showImgNotes: showImgNotes, allowImageAdd: allowImageAdd, name: context.source, validationAttrs:context.validationAttr, options: context.model.displayOptions])
     }
 
     @Override


### PR DESCRIPTION
As per title - also updated the example `images.json` model to reflect these new configuration options.

@chrisala I opted to go the configuration route rather than a new image model, as only hiding 1/2 fields (i.e. just notes) doesn't make the right hand side of the image details section look too sparse.