### PR TITLE
Allow empty values for numericString extender

### DIFF
--- a/grails-app/assets/javascripts/knockout-utils.js
+++ b/grails-app/assets/javascripts/knockout-utils.js
@@ -208,7 +208,8 @@
     ko.extenders.numericString = function(target, options) {
         var defaults = {
             decimalPlaces: 2,
-            removeTrailingZeros: true // backwards compatibility
+            removeTrailingZeros: true, // backwards compatibility
+            allowEmpty: false
         };
         if (_.isNumber(options)) {
             options = {decimalPlaces: options};
@@ -226,8 +227,16 @@
             read: target,  //always return the original observables value
             write: function(newValue) {
                 var val = newValue;
+                var emptyValueToWrite;
                 if (typeof val === 'string') {
                     val = newValue.replace(/,|\$/g, '');
+                }
+                if (options.allowEmpty && (val === null || val === undefined || (typeof val === 'string' && val.trim() === ''))) {
+                    emptyValueToWrite = typeof val === 'string' ? '' : val;
+                    if (emptyValueToWrite !== target()) {
+                        target(emptyValueToWrite);
+                    }
+                    return;
                 }
                 var current = target();
                 var newValueAsNum = isNaN(val) ? 0 : parseFloat(+val);

--- a/grails-app/assets/javascripts/knockout-utils.js
+++ b/grails-app/assets/javascripts/knockout-utils.js
@@ -227,14 +227,12 @@
             read: target,  //always return the original observables value
             write: function(newValue) {
                 var val = newValue;
-                var emptyValueToWrite;
                 if (typeof val === 'string') {
                     val = newValue.replace(/,|\$/g, '');
                 }
                 if (options.allowEmpty && (val === null || val === undefined || (typeof val === 'string' && val.trim() === ''))) {
-                    emptyValueToWrite = typeof val === 'string' ? '' : val;
-                    if (emptyValueToWrite !== target()) {
-                        target(emptyValueToWrite);
+                    if (target() !== null) {
+                        target(null);
                     }
                     return;
                 }

--- a/grails-app/taglib/au/org/ala/ecodata/forms/ModelJSTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/ecodata/forms/ModelJSTagLib.groovy
@@ -237,7 +237,7 @@ class ModelJSTagLib {
 
         switch (model.dataType) {
             case 'number':
-                return '0'
+                return numberAllowsEmpty(ctx) ? 'undefined' : '0'
             case 'stringList':
             case 'image':
                 return '[]'
@@ -249,6 +249,10 @@ class ModelJSTagLib {
             default:
                 return 'undefined'
         }
+    }
+
+    private boolean numberAllowsEmpty(JSModelRenderContext ctx) {
+        ctx.dataModel?.dataType == 'number' && ctx.viewModel()?.displayOptions?.allowEmpty == true
     }
 
     void renderInitialiser(JSModelRenderContext ctx) {
@@ -619,7 +623,7 @@ class ModelJSTagLib {
     def numberViewModel(JSModelRenderContext ctx) {
         int decimalPlaces = ctx.dataModel.decimalPlaces ?: 2
 
-        Map options = new HashMap(ctx.viewModel()?.displayOptions ?: [:])
+        Map options = new LinkedHashMap(ctx.viewModel()?.displayOptions ?: [:])
         options.decimalPlaces = decimalPlaces
         String optionString = (options as JSON).toString()
         observable(ctx, ["{numericString:${optionString}}"])

--- a/grails-app/taglib/au/org/ala/ecodata/forms/ModelJSTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/ecodata/forms/ModelJSTagLib.groovy
@@ -237,7 +237,7 @@ class ModelJSTagLib {
 
         switch (model.dataType) {
             case 'number':
-                return numberAllowsEmpty(ctx) ? 'undefined' : '0'
+                return numberAllowsEmpty(ctx) ? 'null' : '0'
             case 'stringList':
             case 'image':
                 return '[]'

--- a/src/test/groovy/au/org/ala/ecodata/forms/ModelJSTagLibSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/forms/ModelJSTagLibSpec.groovy
@@ -123,7 +123,7 @@ class ModelJSTagLibSpec extends Specification implements TagLibUnitTest<ModelJST
         actualOut.toString().trim() == "data.item1 = ko.observable().extend({numericString:{\"allowEmpty\":true,\"decimalPlaces\":2}}).extend({metadata:{metadata:self.dataModel['item1'], context:self.\$context, config:config}});"
     }
 
-    void "number types configured to allow empty values initialise missing data as undefined"() {
+    void "number types configured to allow empty values initialise missing data as null"() {
         setup:
         ctx.attrs = [model:[viewModel:[[source:'item1', type:'number', displayOptions:[allowEmpty:true]]]]]
         ctx.propertyPath = 'data'
@@ -133,7 +133,7 @@ class ModelJSTagLibSpec extends Specification implements TagLibUnitTest<ModelJST
         tagLib.renderInitialiser(ctx)
 
         then:
-        actualOut.toString().trim() == "data['item1'](ecodata.forms.orDefault(data['item1'], undefined));"
+        actualOut.toString().trim() == "data['item1'](ecodata.forms.orDefault(data['item1'], null));"
     }
 
     void "the existence of an expression based default value should result in the use of the writableComputed extender"() {

--- a/src/test/groovy/au/org/ala/ecodata/forms/ModelJSTagLibSpec.groovy
+++ b/src/test/groovy/au/org/ala/ecodata/forms/ModelJSTagLibSpec.groovy
@@ -74,6 +74,19 @@ class ModelJSTagLibSpec extends Specification implements TagLibUnitTest<ModelJST
         actualOut.toString().trim() == "data['item1'](ecodata.forms.orDefault(data['item1'], undefined));"
     }
 
+    void "number types initialise missing data as zero by default"() {
+        setup:
+        ctx.attrs = [:]
+        ctx.propertyPath = 'data'
+        ctx.dataModel = [dataType:'number',name:'item1']
+
+        when:
+        tagLib.renderInitialiser(ctx)
+
+        then:
+        actualOut.toString().trim() == "data['item1'](ecodata.forms.orDefault(data['item1'], 0));"
+    }
+
     void "number types support a configurable number of decimal places"() {
         setup:
         ctx.attrs = [:]
@@ -95,6 +108,32 @@ class ModelJSTagLibSpec extends Specification implements TagLibUnitTest<ModelJST
         then:
         actualOut.toString().trim() == "data.item1 = ko.observable().extend({numericString:{\"decimalPlaces\":3}});"
 
+    }
+
+    void "number types can be configured to allow empty values"() {
+        setup:
+        ctx.attrs = [model:[viewModel:[[source:'item1', type:'number', displayOptions:[allowEmpty:true]]]]]
+        ctx.propertyPath = 'data'
+        ctx.dataModel = [dataType:'number',name:'item1']
+
+        when:
+        tagLib.numberViewModel(ctx)
+
+        then:
+        actualOut.toString().trim() == "data.item1 = ko.observable().extend({numericString:{\"allowEmpty\":true,\"decimalPlaces\":2}}).extend({metadata:{metadata:self.dataModel['item1'], context:self.\$context, config:config}});"
+    }
+
+    void "number types configured to allow empty values initialise missing data as undefined"() {
+        setup:
+        ctx.attrs = [model:[viewModel:[[source:'item1', type:'number', displayOptions:[allowEmpty:true]]]]]
+        ctx.propertyPath = 'data'
+        ctx.dataModel = [dataType:'number',name:'item1']
+
+        when:
+        tagLib.renderInitialiser(ctx)
+
+        then:
+        actualOut.toString().trim() == "data['item1'](ecodata.forms.orDefault(data['item1'], undefined));"
     }
 
     void "the existence of an expression based default value should result in the use of the writableComputed extender"() {

--- a/src/test/js/spec/NumericStringSpec.js
+++ b/src/test/js/spec/NumericStringSpec.js
@@ -29,11 +29,11 @@ describe("knockout dates spec", function () {
         expect(observable()).toEqual("0");
     });
 
-    it("can preserve empty numeric values when configured", () => {
+    it("can store empty numeric values as null when configured", () => {
         var observable = ko.observable("2").extend({numericString:{decimalPlaces:2, allowEmpty:true}});
 
         observable("");
 
-        expect(observable()).toEqual("");
+        expect(observable()).toBeNull();
     });
 });

--- a/src/test/js/spec/NumericStringSpec.js
+++ b/src/test/js/spec/NumericStringSpec.js
@@ -20,4 +20,20 @@ describe("knockout dates spec", function () {
             expect(observable()).toEqual(inputOutput[i].output);
         }
     });
+
+    it("defaults empty numeric values to zero", () => {
+        var observable = ko.observable("2").extend({numericString:2});
+
+        observable("");
+
+        expect(observable()).toEqual("0");
+    });
+
+    it("can preserve empty numeric values when configured", () => {
+        var observable = ko.observable("2").extend({numericString:{decimalPlaces:2, allowEmpty:true}});
+
+        observable("");
+
+        expect(observable()).toEqual("");
+    });
 });


### PR DESCRIPTION
Add an allowEmpty option to ko.extenders.numericString so empty inputs ("", null, undefined) can be preserved instead of being coerced to 0. The default behaviour remains unchanged (empty values default to 0). Update ModelJSTagLib to initialise number fields as undefined when viewModel.displayOptions.allowEmpty is true (added numberAllowsEmpty helper) and use a LinkedHashMap to preserve option ordering in the generated JSON. Add corresponding unit tests for both frontend and backend to cover the new behaviour.