### PR TITLE
Gradle build deps order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ if (Boolean.valueOf(enableJacoco)) {
 
 repositories {
     mavenLocal()
-    maven { url "https://repo.grails.org/grails/core" }
     maven { url "https://nexus.ala.org.au/content/groups/public/" }
+    maven { url "https://repo.grails.org/grails/core" }
 }
 
 boolean inplace = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xss2048k -Xmx1024M
 exploded=true
 enableClover=false
 enableJacoco=true
-alaSecurityLibsVersion=7.1.0-SNAPSHOT
+alaSecurityLibsVersion=7.1.0


### PR DESCRIPTION
- Switched repository order for gradle
- Updated ALA security libs to non-snapshot version